### PR TITLE
Carrying more columns and csv editor

### DIFF
--- a/scripts/PH_parse_md_B.py
+++ b/scripts/PH_parse_md_B.py
@@ -10,7 +10,7 @@ INPUT_DIR = Path(r"../data/pre-parsed/md_B")
 OUTPUT_DIR_CSV = Path(r"../Exp-Data_Parsed/md_B")
 PREPARSED_META = Path(r"../Metadata/preparsed/md_B")
 OUTPUT_META = Path(r"../Metadata/Parsed/md_B")
-OUTPUT_EXPLORER = Path(r"PH_cone-explorer/data/parsed/md_B")
+
 
 LOG_FILE = Path(r"..") / "parse_md_B_log.json"
 
@@ -129,7 +129,18 @@ def parse_data(file_path):
 
     df = pd.read_csv(file_path)
     df["HRRPUA (kW/m2)"] = df["Q-Dot (kW/m2)"]
-    data = df[["Time (s)","Mass (g)","HRRPUA (kW/m2)"]]
+    if "CO2 (kg/kg)" not in df.columns:
+        df["CO2 (kg/kg)"] = None
+    if "CO (kg/kg)" not in df.columns:
+        df["CO (kg/kg)"] = None
+    if "H2O (kg/kg)" not in df.columns:
+        df["H2O (kg/kg)"] = None
+    if "HCl (kg/kg)" not in df.columns:
+        df["HCl (kg/kg)"] = None
+    if "H'carbs (kg/kg)" not in df.columns:
+        df["H'carbs (kg/kg)"] = None
+    df["HRR (kW)"] = None
+    data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)", "HRRPUA (kW/m2)"]]
 
         
     OUTPUT_DIR_CSV.mkdir(parents=True, exist_ok=True)

--- a/scripts/PH_parse_md_C.py
+++ b/scripts/PH_parse_md_C.py
@@ -10,7 +10,6 @@ INPUT_DIR = Path(r"../data/pre-parsed/md_C")
 OUTPUT_DIR_CSV = Path(r"../Exp-Data_Parsed/md_C")
 PREPARSED_META = Path(r"../Metadata/preparsed/md_C")
 OUTPUT_META = Path(r"../Metadata/Parsed/md_C")
-OUTPUT_EXPLORER = Path(r"PH_cone-explorer/data/parsed/md_C")
 
 LOG_FILE = Path(r"..") / "parse_md_C_log.json"
 
@@ -120,7 +119,7 @@ def parse_file(file_path):
 '''
     
 #region parse_plot_data
-def parse_data(file_path):
+def parse_data(file_path):    
     # extract heat flux from current test
     file_stem = file_path.stem
     meta_file = str(file_stem) + ".json"
@@ -128,15 +127,31 @@ def parse_data(file_path):
         metadata = json.load(w)
 
     df = pd.read_csv(file_path)
+    if "CO2 (kg/kg)" not in df.columns:
+        df["CO2 (kg/kg)"] = None
+    if "CO (kg/kg)" not in df.columns:
+        df["CO (kg/kg)"] = None
+    if "H2O (kg/kg)" not in df.columns:
+        df["H2O (kg/kg)"] = None
+    if "HCl (kg/kg)" not in df.columns:
+        df["HCl (kg/kg)"] = None
+    if "H'carbs (kg/kg)" not in df.columns:
+        df["H'carbs (kg/kg)"] = None
+
     if "Mass (kg)" in df.columns:
         df["Mass (g)"] = df["Mass (kg)"] * 1000
-        data = df[["Time (s)","Mass (g)","HRRPUA (kW/m2)"]]
+        df["HRR (kW)"] = None
+        data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)", "HRRPUA (kW/m2)"]]
     elif "MLR (g/s)" in df.columns:
+        df["Mass (g)"] = None
+        df["HRR (kW)"] = None
         print(colorize(f'Warning: {file_stem} only contains mass loss rate data', "yellow"))
-        data = df[["Time (s)","MLR (g/s)","HRRPUA (kW/m2)"]]
+        data = data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)", "MLR (g/s)", "HRRPUA (kW/m2)"]]
     else:
+        df["Mass (g)"] = None
+        df["HRR (kW)"] = None
         print(colorize(f'Warning: {file_stem} only contains heat relase data', "yellow"))
-        data  = df[["Time (s)","HRRPUA (kW/m2)"]]
+        data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)", "HRRPUA (kW/m2)"]]
         
     OUTPUT_DIR_CSV.mkdir(parents=True, exist_ok=True)
     data_output_path = OUTPUT_DIR_CSV / str(file_path.name)

--- a/scripts/PH_preparse_md_A.py
+++ b/scripts/PH_preparse_md_A.py
@@ -433,7 +433,7 @@ def parse_metadata(input,test_name):
             metadata_json["C Factor"] = get_number(item[3:],"flt")
         elif "INITIAL MASS" in item and "FRACTION" not in item:
             metadata_json["Sample Mass (g)"] = get_number(item[3:],"flt")
-        elif "FINAL MASS=" in item and "FRACTION" not in item:
+        elif "FINAL MASS" in item and "FRACTION" not in item:
             metadata_json["Residual Mass (g)"] = get_number(item[3:],"flt")
         elif "AREA OF SAMPLE" in item and not metadata_json.get("Surface Area (m2)"):
             #print('area')
@@ -458,6 +458,8 @@ def parse_metadata(input,test_name):
             match = re.search(r'TEST\s+(\d{4})', item)
             if match:
                 metadata_json["Specimen Number"] = int(match.group(1))
+        elif "INITIAL WEIGHT" in item and not metadata_json.get("Sample Mass (g)"):
+            metadata_json["Sample Mass (g)"] = get_number(item[3:],"flt")
         elif re.search(r'\d+\s+[A-Z]{3}\s+\d{4}', item) is not None:
             metadata_json["Test Date"] = item
         else:
@@ -483,9 +485,7 @@ def parse_metadata(input,test_name):
         "Test Date",
         "Residue Yield (g/g)"
     ]
-        #autoprocessed values
-    if ("Sample Mass (g)" in metadata_json) and ("Residual Mass (g)" in metadata_json) and (metadata_json["Sample Mass (g)"] != None) and (metadata_json["Sample Mass (g)"] != None):
-        metadata_json["Residue Yield (g/g)"] = float(metadata_json["Residual Mass (g)"]) / float(metadata_json["Sample Mass (g)"])
+
     for key in expected_keys:
         metadata_json.setdefault(key, None)
     metadata_json['Original Testname'] = test_name
@@ -501,7 +501,7 @@ def parse_metadata(input,test_name):
     metadata_json["Manually Reviewed Series"] = None
     metadata_json['Pass Review'] = None
     metadata_json["Published"] = None
-
+    metadata_json["Markdown Format"] = "A"
     metadata_json['Data Corrections'] =[]
     #update respective test metadata file
     with open(meta_path, "w", encoding="utf-8") as f:

--- a/scripts/PH_preparse_md_B.py
+++ b/scripts/PH_preparse_md_B.py
@@ -71,9 +71,9 @@ def parse_dir(input_dir):
             out_path = Path(str(path).replace('md_B', 'md_B_partial'))
 
         # If output path is set, ensure the directory exists and copy
-        #if out_path:
-        #    out_path.parent.mkdir(parents=True, exist_ok=True)
-        #    shutil.move(path, out_path)
+        if out_path:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(path, out_path)
     print(colorize(f"Files pre-parsed fully: {files_parsed_fully}/{files_parsed} ({((files_parsed_fully)/files_parsed) * 100}%)", "blue"))
     print(colorize(f"Files pre-parsed partially: {files_parsed_partial}/{files_parsed} ({((files_parsed_partial)/files_parsed) * 100}%)", "blue"))
     
@@ -346,9 +346,8 @@ def parse_data(data_df,test,file_name):
             data_df.columns.values[i] = "Sum Q (MJ/m2)"
         elif "MASS" in column:
             data_df.columns.values[i] = "Mass (g)"
-        elif "MLOSS" in str(column.replace(" ", "")):
-            if "M-Dot (g/s-m2)" not in data_df.columns.values:
-                data_df.columns.values[i] = "MLR (g/s)"
+        elif "M" in column and "LOSS" in column:
+            data_df.columns.values[i] = "MLR (g/s)"
         elif "COMB" in column:
             data_df.columns.values[i] = "HT Comb (MJ/kg)"
         elif "CO2" in column or "C02" in column:
@@ -447,8 +446,6 @@ def parse_metadata(input,test_name):
                 match = re.search(r'([^\s]+(?:\s*KW/M2))', item)
                 substring = match.group(1) if match else None
             metadata_json["Heat Flux (kW/m2)"] = get_number(substring, "int")
-        if "MAX TIME" in item:
-            metadata_json["time_s"] = get_number(item, "flt")
         elif "MAX HEAT RELEASE" in item:
             metadata_json["Peak Heat Release Rate (kW/m2)"] = get_number(item, "flt")
         elif "HOR" in item:
@@ -487,9 +484,7 @@ def parse_metadata(input,test_name):
         "Test Date",
         "Residue Yield (g/g)"
     ]
-        #autoprocessed values
-    if ("Sample Mass (g)" in metadata_json) and ("Residual Mass (g)" in metadata_json) and (metadata_json["Sample Mass (g)"] != None) and (metadata_json["Sample Mass (g)"] != None):
-        metadata_json["Residue Yield (g/g)"] = float(metadata_json["Residual Mass (g)"]) / float(metadata_json["Sample Mass (g)"])
+    
     for key in expected_keys:
         metadata_json.setdefault(key, None)
     metadata_json['Original Testname'] = test_name
@@ -505,7 +500,7 @@ def parse_metadata(input,test_name):
     metadata_json["Manually Reviewed Series"] = None
     metadata_json['Pass Review'] = None
     metadata_json["Published"] = None
-
+    metadata_json["Markdown Format"] = "B"
     metadata_json['Data Corrections'] =[]
 
     #update respective test metadata file

--- a/scripts/PH_preparse_md_C.py
+++ b/scripts/PH_preparse_md_C.py
@@ -54,9 +54,9 @@ def parse_dir(input_dir):
             out_path = Path(str(path).replace('md_C', 'md_C_partial'))
 
         # If output path is set, ensure the directory exists and move
-        #if out_path:
-         #   out_path.parent.mkdir(parents=True, exist_ok=True)
-          #  shutil.move(path, out_path)
+        if out_path:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(path, out_path)
     print(colorize(f"Files pre-parsed fully: {files_parsed_fully}/{files_parsed} ({((files_parsed_fully)/files_parsed) * 100}%)", "blue"))
     print(colorize(f"Files pre-parsed partially: {files_parsed_partial}/{files_parsed} ({((files_parsed_partial)/files_parsed) * 100}%)", "blue"))
  
@@ -321,7 +321,7 @@ def parse_data(data_df,test,file_name):
             # Additional check: Is this column monotonically decreasing?
             col_vals = pd.to_numeric(data_df[column], errors='coerce').dropna()
             # Check monotonic decreasing
-            if (col_vals.diff().dropna() <= 0).all():
+            if (col_vals.diff().dropna() <= 0).all() and (col_vals != 0.0).all():
                 data_df.columns.values[i] = "Mass (kg)"
             else:
                 data_df.columns.values[i] = "MLR (g/s)"
@@ -332,7 +332,6 @@ def parse_data(data_df,test,file_name):
         elif ("CO" in column or "C0" in column) and "2" not in column:
             data_df.columns.values[i] = "CO (kg/kg)"
         elif "AIR" in column:
-            #some of the O were seen as 0, H2 to remove error
             data_df.columns.values[i] = "Air/Sample (kg/kg)"
         else:
             msg = f'Illegal Column Detected: {column}'
@@ -444,7 +443,7 @@ def parse_metadata(input,test_name):
     metadata_json["Manually Reviewed Series"] = None
     metadata_json['Pass Review'] = None
     metadata_json["Published"] = None
-
+    metadata_json["Markdown Format"] = "C"
     metadata_json['Data Corrections'] =[]
     #update respective test metadata file
     with open(meta_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Preparsing: 
- minor data and metadata detection changes
- removed residual mass autoprocessed value- just causing errors/will calculate in autoprocessing script
- added md format metadata item for tracking purposes
- uncommented file moving paths
Parsing:
- carry species yield columns through
- always have default mass (g) and HRR (kW) columns, even if blank
- data in wrong format (ie MLR, anything PUA) appened at the end
Plot and Data Editor
- made a more uniform dataframe generation that works with the new input data format from all markdown types
- Saving clipped data outputs the most basic units for df: (ex: if a surface area was found for a test that previously did not have it, the nonPUA data would be saved
- Added the ability to directly modify the csv file. This would be useful in the case that the preparsing script either accidently clipped out a chunk of data, inserted data that shouldnt be there, or moved data from one column to the other.