### PR TITLE
Parsing and Preparsing Fixes

### DIFF
--- a/scripts/PH_parse_md_A.py
+++ b/scripts/PH_parse_md_A.py
@@ -143,7 +143,7 @@ def parse_data(file_path):
     increments = np.diff(times)
     expected_step = np.median(increments)
     #steps continous equal continue changing by the same amount appx (allow for single skip ie times 2) or slight less
-    continuous = np.all((increments >= expected_step *.5) & (increments <= expected_step *2))
+    continuous = np.all((increments >= expected_step *.1) & (increments <= expected_step *5))
     if not continuous:
         raise Exception("Test does not have continuous time data, please review preparsed csv file, markdown, and pdf")
 
@@ -159,6 +159,8 @@ def parse_data(file_path):
         df["HCl (kg/kg)"] = None
     if "H'carbs (kg/kg)" not in df.columns:
         df["H'carbs (kg/kg)"] = None
+    if "K Smoke (1/m)" not in df.columns:
+        df["K Smoke (1/m)"] = None
     if surf_area == None:
         print(colorize(f'Warning: {file_stem} does not have a defined surface area, data is output per unit area', "yellow"))
         df["HRRPUA (kW/m2)"] = abs(df["Q-Dot (kW/m2)"])
@@ -167,35 +169,41 @@ def parse_data(file_path):
                 df["MassPUA (g/m2)"] = mass - (df["Mass Loss (kg/m2)"]* 1000) #surface area m2, 1000g/kg
                 df["Mass (g)"] = None
                 df["HRR (kW)"] = None
-                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)", "MassPUA (g/m2)","HRRPUA (kW/m2)"]]
+                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)",
+                            "H'carbs (kg/kg)","K Smoke (1/m)","Extinction Area (m2/kg)", "MassPUA (g/m2)","HRRPUA (kW/m2)"]]
             else: 
                 print(colorize(f'Warning: {file_stem} is missing sample mass, mass loss is output', "yellow"))
                 df["Mass LossPUA (g/m2)"] = (df["Mass Loss (kg/m2)"]* 1000)
                 df["Mass (g)"] = None
                 df["HRR (kW)"] = None
-                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)","Mass LossPUA (g/m2)","HRRPUA (kW/m2)"]]
+                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)",
+                            "H'carbs (kg/kg)","K Smoke (1/m)","Extinction Area (m2/kg)","Mass LossPUA (g/m2)","HRRPUA (kW/m2)"]]
         else:
             print(colorize(f'Warning: {file_stem} only contains mass loss rate data', "yellow"))
             df["MLRPUA (g/s-m2)"] = df["M-Dot (g/s-m2)"]
             df["Mass (g)"] = None
             df["HRR (kW)"] = None
-            data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)","MLRPUA (g/s-m2)","HRRPUA (kW/m2)"]]
+            data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)",
+                        "H'carbs (kg/kg)","K Smoke (1/m)","Extinction Area (m2/kg)","MLRPUA (g/s-m2)","HRRPUA (kW/m2)"]]
     else:
         df["HRR (kW)"] = surf_area * abs(df["Q-Dot (kW/m2)"])
         if "Mass Loss (kg/m2)" in df.columns:
             if mass != None:
                 df["Mass (g)"] = mass - (df["Mass Loss (kg/m2)"] * surf_area * 1000) #surface area m2, 1000g/kg
-                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)",]]
+                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", 
+                           "H'carbs (kg/kg)","K Smoke (1/m)","Extinction Area (m2/kg)"]]
             else:
                 print(colorize(f'Warning: {file_stem} is missing sample mass, mass loss is output', "yellow"))
                 df["Mass Loss (g)"] = (df["Mass Loss (kg/m2)"] * surf_area * 1000)
                 df["Mass (g)"] = None
-                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)","Mass Loss (g)"]]
+                data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)",
+                            "H'carbs (kg/kg)","K Smoke (1/m)","Extinction Area (m2/kg)","Mass Loss (g)"]]
         else:
             print(colorize(f'Warning: {file_stem} only contains mass loss rate data', "yellow"))
             df["MLR (g/s)"] = df["M-Dot (g/s-m2)"] * surf_area
             df["Mass (g)"] = None
-            data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)","MLR (g/s)"]]
+            data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)",
+                        "H'carbs (kg/kg)","K Smoke (1/m)","Extinction Area (m2/kg)","MLR (g/s)"]]
 
 
     OUTPUT_DIR_CSV.mkdir(parents=True, exist_ok=True)

--- a/scripts/PH_parse_md_B.py
+++ b/scripts/PH_parse_md_B.py
@@ -139,7 +139,7 @@ def parse_data(file_path):
     increments = np.diff(times)
     expected_step = np.median(increments)
     #steps continous equal continue changing by the same amount appx (allow for single skip ie times 2) or slight less
-    continuous = np.all((increments >= expected_step *.5) & (increments <= expected_step *2))
+    continuous = np.all((increments >= expected_step *.1) & (increments <= expected_step *5))
     if not continuous:
         raise Exception("Test does not have continuous time data, please review preparsed csv file, markdown, and pdf")
 
@@ -154,8 +154,12 @@ def parse_data(file_path):
         df["HCl (kg/kg)"] = None
     if "H'carbs (kg/kg)" not in df.columns:
         df["H'carbs (kg/kg)"] = None
+    df["MLR (kg/s)"] = df["MLR (g/s)"]/1000
+    #Derive ksmoke using MLR, V-Duct, and Specific extinction area on fuel pyrolyzate basis (sigma f not sigma s)
+    df["K Smoke (1/m)"] = (df["MLR (g/s)"]* df["Extinction Area (m2/kg)"])/df["V-Duct (m3/s)"]
     df["HRR (kW)"] = None
-    data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", "H'carbs (kg/kg)", "HRRPUA (kW/m2)"]]
+    data = df[["Time (s)","Mass (g)","HRR (kW)", "CO2 (kg/kg)","CO (kg/kg)", "H2O (kg/kg)", "HCl (kg/kg)", 
+               "H'carbs (kg/kg)","K Smoke (1/m)","Extinction Area (m2/kg)", "HRRPUA (kW/m2)"]]
 
         
     OUTPUT_DIR_CSV.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Parsing:
For all, relax the continous time requirement, was catching things with just incongruent time steps (ie 3 most then 1 for a step), only want to catch drop back to zero or major jump from typo
All tests now carry K-Smoke column and extinction area column: both none for md_c, md_A always has extinction area and more columns has K-Smoke, md_B always hs extinction area and K-Smoke can  be calculated via MLR and V-duct

Preparsing: 
For all, implemented traceback so we can log where errors are coming from
Cleaned up column identification and modified some names
For md_c, completley overhauled test identification. These files have inconsistent placement of metadata in reference to their table headers, so this logic is able to identify the breakpoint in a new test by either and populated tests accordingly. There is also logic to block processing of the file if the number of table headers and metadata fields are incongruent (meaning there is leftover data in "UNLABLED"). This may occur if the metadata field is malformed (on multiple lines, different delimiters, etc...), leading to the wrong data being associated with the wrong tests. Typically, these issues simply rwequire minor adjustments to the markdowns.