### PR TITLE
Protection against faulty test separation

### DIFF
--- a/scripts/PH_parse_md_A.py
+++ b/scripts/PH_parse_md_A.py
@@ -56,7 +56,7 @@ def parse_dir(input_dir):
             with open(LOG_FILE, "r", encoding="utf-8") as w:  
                 logfile = json.load(w)
             logfile.update({
-                    str(path.name)[0:8:1] : "Parsing Issue: " + str(e)
+                    str(path.name) : "Parsing Issue: " + str(e)
                 })
             with open(LOG_FILE, "w", encoding="utf-8") as f:
 	            f.write(json.dumps(logfile, indent=4))

--- a/scripts/PH_parse_md_B.py
+++ b/scripts/PH_parse_md_B.py
@@ -56,7 +56,7 @@ def parse_dir(input_dir):
             with open(LOG_FILE, "r", encoding="utf-8") as w:  
                 logfile = json.load(w)
             logfile.update({
-                    str(path.name)[0:8:1] : "Parsing Issue: " + str(e)
+                    str(path.name): "Parsing Issue: " + str(e)
                 })
             with open(LOG_FILE, "w", encoding="utf-8") as f:
 	            f.write(json.dumps(logfile, indent=4))


### PR DESCRIPTION
For test by test exceptions, implemented a traceback to see where exactly the failure occurred within the preparsing script (lowest level excluding get_number which is not specific).

Overall implemented exceptions in the get_tests function that catch instances of test number typos: these issues are severe as they can lead to the incorrect assignment of data or its absences. Issues are also relativley easy to fix by hand for SmURFS, requiring only that they quickly parse through the file and edit the test numbers/add them based on the pdf.

PreparseA: If the test number jumps back to a previous number, this indicates that rather than a new test, a poorly parsed test number existed. The exception is raised, and the file is not preparsed until it is corrected.

PreparseB:  Logic to identify the start of a test already exists, but now if there is an issue with the test number internally, the exception is raised. This protects from cases where the first test number was incorrect.

PreparseC: If no test number can be found for a test (some are handwritten and not picked up by llama) or if there is an incongruency in header and metadata fields leading to unlabeled data, and exception is raised.